### PR TITLE
Add HighResolutionTimer to beam_utils

### DIFF
--- a/beam_utils/include/beam/utils/time.hpp
+++ b/beam_utils/include/beam/utils/time.hpp
@@ -8,26 +8,60 @@
 #ifndef BEAM_UTILS_TIME_HPP
 #define BEAM_UTILS_TIME_HPP
 
-#include <time.h>
+#include <chrono>
+#include <ctime>
 #include <sys/time.h>
 
 namespace beam {
 /** @addtogroup utils
  *  @{ */
 
+/**
+ * @brief Simple timer object
+ */
+struct HighResolutionTimer {
+  HighResolutionTimer() : start_time(take_time_stamp()) {}
+
+  /**
+   * @brief Restart timer
+   */
+  void restart() { start_time = take_time_stamp(); }
+
+  /**
+   * @brief Return elapsed time in seconds.
+   * @return
+   */
+  double elapsed() const {
+    return double(take_time_stamp() - start_time) * 1e-9;
+  }
+
+  std::uint64_t elapsed_nanoseconds() const {
+    return take_time_stamp() - start_time;
+  }
+
+protected:
+  static std::uint64_t take_time_stamp() {
+    return std::uint64_t(
+        std::chrono::high_resolution_clock::now().time_since_epoch().count());
+  }
+
+private:
+  std::uint64_t start_time;
+};
+
 /** Similar to how matlab's tic and toc work, `tic()` starts the timer where the
  * variable `t` stores the start time, when `toc()` is called it returns the
  * time
  * difference in seconds. `mtoc()` returns the time difference in milli-seconds.
  */
-void tic(struct timespec *tic);
-float toc(struct timespec *tic);
-float mtoc(struct timespec *tic);
+void tic(struct timespec* tic);
+float toc(struct timespec* tic);
+float mtoc(struct timespec* tic);
 
 /** @return the time since epoch in seconds. */
 double time_now(void);
 
 /** @} group utils */
-}  // namespace beam
+} // namespace beam
 
-#endif  // BEAM_UTILS_TIME_HPP
+#endif // BEAM_UTILS_TIME_HPP

--- a/beam_utils/src/time.cpp
+++ b/beam_utils/src/time.cpp
@@ -1,31 +1,30 @@
 #include "beam/utils/time.hpp"
 
-
 namespace beam {
 
-void tic(struct timespec *tic) {
-    clock_gettime(CLOCK_MONOTONIC, tic);
+void tic(struct timespec* tic) {
+  clock_gettime(CLOCK_MONOTONIC, tic);
 }
 
-float toc(struct timespec *tic) {
-    struct timespec toc;
-    float time_elasped;
+float toc(struct timespec* tic) {
+  struct timespec toc;
+  float time_elasped;
 
-    clock_gettime(CLOCK_MONOTONIC, &toc);
-    time_elasped = (toc.tv_sec - tic->tv_sec);
-    time_elasped += (toc.tv_nsec - tic->tv_nsec) / 1000000000.0;
+  clock_gettime(CLOCK_MONOTONIC, &toc);
+  time_elasped = (toc.tv_sec - tic->tv_sec);
+  time_elasped += (toc.tv_nsec - tic->tv_nsec) / 1000000000.0;
 
-    return time_elasped;
+  return time_elasped;
 }
 
-float mtoc(struct timespec *tic) {
-    return toc(tic) * 1000.0;
+float mtoc(struct timespec* tic) {
+  return toc(tic) * 1000.0;
 }
 
 double time_now(void) {
-    struct timeval t;
-    gettimeofday(&t, NULL);
-    return ((double) t.tv_sec + ((double) t.tv_usec) / 1000000.0);
+  struct timeval t;
+  gettimeofday(&t, NULL);
+  return ((double)t.tv_sec + ((double)t.tv_usec) / 1000000.0);
 }
 
-}  // namespace beam
+} // namespace beam


### PR DESCRIPTION
Example usage:
```
beam_utils::HighResolutionTimer timer; // Create & start timer
timer.elapsed(); // Returns elapsed time in seconds
timer.restart(); // Restarts timer
```
