### PR TITLE
Adding << operator for writing to std::cout 

### DIFF
--- a/beam_calibration/include/beam/calibration/Pinhole.h
+++ b/beam_calibration/include/beam/calibration/Pinhole.h
@@ -204,6 +204,11 @@ public:
    */
   beam::Vec2 ProjectDistortedPoint(beam::Vec4 &X);
 
+  /**
+   * @brief Overload for pushing to output streams
+   */
+  friend std::ostream& operator<< (std::ostream& out, Pinhole& pinhole);
+
 private:
   /**
    * @brief This applies the projection for to images that are not distorted

--- a/beam_calibration/src/Pinhole.cpp
+++ b/beam_calibration/src/Pinhole.cpp
@@ -375,4 +375,13 @@ beam::Vec2 Pinhole::ApplyDistortedProjection(beam::Vec3& X) {
   return coords;
 }
 
+std::ostream& operator<<(std::ostream& out, Pinhole& pinhole){
+  out << "Calibration date: " << pinhole.GetCalibrationDate() << std::endl;
+  out << "Frame ID: " << pinhole.GetFrameId() << std::endl;
+  out << "Image center: [cx, cy] = [" << pinhole.GetCx() << ", " << pinhole.GetCy() << "]." << std::endl;
+  out << "Focal length: [fx, fy] = [" << pinhole.GetFx() << ", " << pinhole.GetFy() << "]." << std::endl;
+  out << "Image dimensions: [w, h] = [" << pinhole.GetImgDims()[0] << ", " << pinhole.GetImgDims()[1] << "]." << std::endl;
+  return out;
+}
+
 } // namespace beam_calibration


### PR DESCRIPTION
(enables `std::cout << pinhole << std::endl` - useful for debugging)