### PR TITLE
Updating CMakeLists

### DIFF
--- a/beam_calibration/CMakeLists.txt
+++ b/beam_calibration/CMakeLists.txt
@@ -1,12 +1,10 @@
 PROJECT(beam_calibration)
 
-#include_directories(${catkin_INCLUDE_DIRS})
-
 BEAM_ADD_MODULE(${PROJECT_NAME}
   DEPENDS
     beam::utils
+  Boost::boost
     catkin::catkin
-    ${Boost_LIBRARIES}
     Eigen3::Eigen
     Catch2::Catch2
     nlohmann_json::nlohmann_json
@@ -43,9 +41,9 @@ target_include_directories(${PROJECT_NAME}_extrinsics_tests
 target_link_libraries(${PROJECT_NAME}_extrinsics_tests
   ${PROJECT_NAME}
   Catch2::Catch2
-  ${catkin_LIBRARIES}
-  ${Boost_LIBRARIES}
-)
+  Boost::boost
+  catkin::catkin
+  )
 #######################################
 
 ############# Debug files #############
@@ -58,6 +56,6 @@ target_include_directories(${PROJECT_NAME}_debug
 )
 target_link_libraries(${PROJECT_NAME}_debug
   ${PROJECT_NAME}
-  ${catkin_LIBRARIES}
+  catkin::catkin
 )
 #######################################

--- a/beam_utils/CMakeLists.txt
+++ b/beam_utils/CMakeLists.txt
@@ -1,12 +1,12 @@
 PROJECT(beam_utils)
 
 BEAM_ADD_MODULE(${PROJECT_NAME}
-    DEPENDS
+  DEPENDS
     Eigen3::Eigen
     catkin::catkin
     yaml-cpp
-    SOURCES
+  SOURCES
     src/math.cpp
     src/time.cpp
     src/angles.cpp
-    )
+  )


### PR DESCRIPTION
This should solve the CMake warning we were getting where there were problems finding Boost whenever we tried to link against beam::calibration (see below for example)

```
CMake Warning at /usr/local/share/beam/cmake/beamConfig.cmake:87 (MESSAGE):
  Missing /usr/lib/x86_64-linux-gnu/libboost_atomic.so, required for
  beam::calibration
```