### PR TITLE
replace cv_bridge with ImgToMat beam_cv util

### DIFF
--- a/beam_colorize/src/Colorizer.cpp
+++ b/beam_colorize/src/Colorizer.cpp
@@ -3,11 +3,10 @@
 #include <pcl/common/transforms.h>
 #include <pcl/io/pcd_io.h>
 
-#include <beam_cv/Utils.h>
-
 #include "beam_colorize/Colorizer.h"
 #include "beam_colorize/Projection.h"
 #include "beam_colorize/RayTrace.h"
+#include <beam_cv/OpenCVConversions.h>
 
 namespace beam_colorize {
 Colorizer::Colorizer() {
@@ -46,7 +45,8 @@ void Colorizer::SetImage(const cv::Mat& image_input) {
 }
 
 void Colorizer::SetImage(const sensor_msgs::Image& image_input) {
-  image_ = std::make_shared<cv::Mat>(beam_cv::ImgToMat(image_input));
+  image_ = std::make_shared<cv::Mat>(
+      beam_cv::OpenCVConversions::ImgToMat(image_input));
   image_initialized_ = true;
 }
 

--- a/beam_cv/CMakeLists.txt
+++ b/beam_cv/CMakeLists.txt
@@ -13,6 +13,7 @@ BEAM_ADD_MODULE(${PROJECT_NAME}
   SOURCES
     src/Utils.cpp
     src/Raycast.cpp
+    src/OpenCVConversions.cpp
     src/geometry/Triangulation.cpp
     src/geometry/RelativePoseEstimator.cpp
     src/geometry/AbsolutePoseEstimator.cpp

--- a/beam_cv/include/beam_cv/OpenCVConversions.h
+++ b/beam_cv/include/beam_cv/OpenCVConversions.h
@@ -1,0 +1,25 @@
+#include <opencv2/opencv.hpp>
+
+#include <boost/make_shared.hpp>
+#include <boost/regex.hpp>
+#include <sensor_msgs/Image.h>
+
+namespace beam_cv {
+
+class OpenCVConversions {
+public:
+  // ImgToMat helper
+  static int DepthStrToInt(const std::string depth);
+
+  // ImgToMat helper
+  static int GetCvType(const std::string& encoding);
+
+  /**
+   * @brief Converts a ROS Image to a cv::Mat by sharing the data or changing
+   * its endianness if needed
+   * @param source ros image message
+   * @return cv::Mat of image
+   */
+  static cv::Mat ImgToMat(const sensor_msgs::Image& source);
+};
+} // namespace beam_cv

--- a/beam_cv/include/beam_cv/Utils.h
+++ b/beam_cv/include/beam_cv/Utils.h
@@ -12,8 +12,6 @@
 #include <beam_utils/math.h>
 #include <beam_utils/optional.h>
 
-#include <sensor_msgs/Image.h>
-
 namespace beam_cv {
 
 typedef Eigen::aligned_allocator<Eigen::Vector4d> AlignVec4d;
@@ -207,14 +205,6 @@ void DetectAndCompute(const cv::Mat& image,
 double ComputeMedianMatchDistance(std::vector<cv::DMatch> matches,
                                   const std::vector<cv::KeyPoint>& keypoints_1,
                                   const std::vector<cv::KeyPoint>& keypoints_2);
-
-/**
- * @brief Converts a ROS Image to a cv::Mat by sharing the data or changing its
- * endianness if needed
- * @param source ros image message
- * @return cv::Mat of image
- */
-cv::Mat ImgToMat(const sensor_msgs::Image& source);
 
 /**
  * @brief This class provides a simple yet efficient Union-Find data structure

--- a/beam_cv/src/OpenCVConversions.cpp
+++ b/beam_cv/src/OpenCVConversions.cpp
@@ -1,0 +1,125 @@
+#include <beam_cv/OpenCVConversions.h>
+
+#include <boost/endian/conversion.hpp>
+#include <sensor_msgs/image_encodings.h>
+
+namespace enc = sensor_msgs::image_encodings;
+
+namespace beam_cv {
+
+// ImgToMat helper
+int OpenCVConversions::DepthStrToInt(const std::string depth) {
+  if (depth == "8U") {
+    return 0;
+  } else if (depth == "8S") {
+    return 1;
+  } else if (depth == "16U") {
+    return 2;
+  } else if (depth == "16S") {
+    return 3;
+  } else if (depth == "32S") {
+    return 4;
+  } else if (depth == "32F") {
+    return 5;
+  }
+  return 6;
+}
+
+// ImgToMat helper
+int OpenCVConversions::GetCvType(const std::string& encoding) {
+  // Check for the most common encodings first
+  if (encoding == enc::BGR8) return CV_8UC3;
+  if (encoding == enc::MONO8) return CV_8UC1;
+  if (encoding == enc::RGB8) return CV_8UC3;
+  if (encoding == enc::MONO16) return CV_16UC1;
+  if (encoding == enc::BGR16) return CV_16UC3;
+  if (encoding == enc::RGB16) return CV_16UC3;
+  if (encoding == enc::BGRA8) return CV_8UC4;
+  if (encoding == enc::RGBA8) return CV_8UC4;
+  if (encoding == enc::BGRA16) return CV_16UC4;
+  if (encoding == enc::RGBA16) return CV_16UC4;
+
+  // For bayer, return one-channel
+  if (encoding == enc::BAYER_RGGB8) return CV_8UC1;
+  if (encoding == enc::BAYER_BGGR8) return CV_8UC1;
+  if (encoding == enc::BAYER_GBRG8) return CV_8UC1;
+  if (encoding == enc::BAYER_GRBG8) return CV_8UC1;
+  if (encoding == enc::BAYER_RGGB16) return CV_16UC1;
+  if (encoding == enc::BAYER_BGGR16) return CV_16UC1;
+  if (encoding == enc::BAYER_GBRG16) return CV_16UC1;
+  if (encoding == enc::BAYER_GRBG16) return CV_16UC1;
+
+  // Miscellaneous
+  if (encoding == enc::YUV422) return CV_8UC2;
+
+  // Check all the generic content encodings
+  boost::cmatch m;
+
+  if (boost::regex_match(
+          encoding.c_str(), m,
+          boost::regex("(8U|8S|16U|16S|32S|32F|64F)C([0-9]+)"))) {
+    return CV_MAKETYPE(DepthStrToInt(m[1].str()), atoi(m[2].str().c_str()));
+  }
+
+  if (boost::regex_match(encoding.c_str(), m,
+                         boost::regex("(8U|8S|16U|16S|32S|32F|64F)"))) {
+    return CV_MAKETYPE(DepthStrToInt(m[1].str()), 1);
+  }
+
+  throw std::runtime_error("Unrecognized image encoding [" + encoding + "]");
+}
+
+cv::Mat OpenCVConversions::ImgToMat(const sensor_msgs::Image& source) {
+  int source_type = GetCvType(source.encoding);
+  int byte_depth = enc::bitDepth(source.encoding) / 8;
+  int num_channels = enc::numChannels(source.encoding);
+
+  if (source.step < source.width * byte_depth * num_channels) {
+    std::stringstream ss;
+    ss << "Image is wrongly formed: step < width * byte_depth * num_channels  "
+          "or  "
+       << source.step << " != " << source.width << " * " << byte_depth << " * "
+       << num_channels;
+    throw std::runtime_error(ss.str());
+  }
+
+  if (source.height * source.step != source.data.size()) {
+    std::stringstream ss;
+    ss << "Image is wrongly formed: height * step != size  or  "
+       << source.height << " * " << source.step << " != " << source.data.size();
+    throw std::runtime_error(ss.str());
+  }
+
+  // If the endianness is the same as locally, share the data
+  cv::Mat mat(source.height, source.width, source_type,
+              const_cast<uchar*>(&source.data[0]), source.step);
+  if ((boost::endian::order::native == boost::endian::order::big &&
+       source.is_bigendian) ||
+      (boost::endian::order::native == boost::endian::order::little &&
+       !source.is_bigendian) ||
+      byte_depth == 1)
+    return mat;
+
+  // Otherwise, reinterpret the data as bytes and switch the channels
+  // accordingly
+  mat = cv::Mat(source.height, source.width,
+                CV_MAKETYPE(CV_8U, num_channels * byte_depth),
+                const_cast<uchar*>(&source.data[0]), source.step);
+  cv::Mat mat_swap(source.height, source.width, mat.type());
+
+  std::vector<int> fromTo;
+  fromTo.reserve(num_channels * byte_depth);
+  for (int i = 0; i < num_channels; ++i)
+    for (int j = 0; j < byte_depth; ++j) {
+      fromTo.push_back(byte_depth * i + j);
+      fromTo.push_back(byte_depth * i + byte_depth - 1 - j);
+    }
+  cv::mixChannels(std::vector<cv::Mat>(1, mat),
+                  std::vector<cv::Mat>(1, mat_swap), fromTo);
+
+  // Interpret mat_swap back as the proper type
+  mat_swap.reshape(num_channels);
+
+  return mat_swap;
+}
+} // namespace beam_cv

--- a/beam_cv/src/Utils.cpp
+++ b/beam_cv/src/Utils.cpp
@@ -1,16 +1,10 @@
 #include <beam_cv/Utils.h>
 
-#include "boost/endian/conversion.hpp"
 #include <algorithm>
-#include <boost/make_shared.hpp>
-#include <boost/regex.hpp>
-#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui_c.h>
 
 #include <beam_cv/geometry/Triangulation.h>
-
-namespace enc = sensor_msgs::image_encodings;
 
 namespace beam_cv {
 
@@ -357,128 +351,6 @@ double
   } else {
     return -1.0;
   }
-}
-
-// ImgToMat helper
-class Exception : public std::runtime_error {
-public:
-  Exception(const std::string& description) : std::runtime_error(description) {}
-};
-
-// ImgToMat helper
-static int depthStrToInt(const std::string depth) {
-  if (depth == "8U") {
-    return 0;
-  } else if (depth == "8S") {
-    return 1;
-  } else if (depth == "16U") {
-    return 2;
-  } else if (depth == "16S") {
-    return 3;
-  } else if (depth == "32S") {
-    return 4;
-  } else if (depth == "32F") {
-    return 5;
-  }
-  return 6;
-}
-
-// ImgToMat helper
-int getCvType(const std::string& encoding) {
-  // Check for the most common encodings first
-  if (encoding == enc::BGR8) return CV_8UC3;
-  if (encoding == enc::MONO8) return CV_8UC1;
-  if (encoding == enc::RGB8) return CV_8UC3;
-  if (encoding == enc::MONO16) return CV_16UC1;
-  if (encoding == enc::BGR16) return CV_16UC3;
-  if (encoding == enc::RGB16) return CV_16UC3;
-  if (encoding == enc::BGRA8) return CV_8UC4;
-  if (encoding == enc::RGBA8) return CV_8UC4;
-  if (encoding == enc::BGRA16) return CV_16UC4;
-  if (encoding == enc::RGBA16) return CV_16UC4;
-
-  // For bayer, return one-channel
-  if (encoding == enc::BAYER_RGGB8) return CV_8UC1;
-  if (encoding == enc::BAYER_BGGR8) return CV_8UC1;
-  if (encoding == enc::BAYER_GBRG8) return CV_8UC1;
-  if (encoding == enc::BAYER_GRBG8) return CV_8UC1;
-  if (encoding == enc::BAYER_RGGB16) return CV_16UC1;
-  if (encoding == enc::BAYER_BGGR16) return CV_16UC1;
-  if (encoding == enc::BAYER_GBRG16) return CV_16UC1;
-  if (encoding == enc::BAYER_GRBG16) return CV_16UC1;
-
-  // Miscellaneous
-  if (encoding == enc::YUV422) return CV_8UC2;
-
-  // Check all the generic content encodings
-  boost::cmatch m;
-
-  if (boost::regex_match(
-          encoding.c_str(), m,
-          boost::regex("(8U|8S|16U|16S|32S|32F|64F)C([0-9]+)"))) {
-    return CV_MAKETYPE(depthStrToInt(m[1].str()), atoi(m[2].str().c_str()));
-  }
-
-  if (boost::regex_match(encoding.c_str(), m,
-                         boost::regex("(8U|8S|16U|16S|32S|32F|64F)"))) {
-    return CV_MAKETYPE(depthStrToInt(m[1].str()), 1);
-  }
-
-  throw Exception("Unrecognized image encoding [" + encoding + "]");
-}
-
-cv::Mat ImgToMat(const sensor_msgs::Image& source) {
-  int source_type = getCvType(source.encoding);
-  int byte_depth = enc::bitDepth(source.encoding) / 8;
-  int num_channels = enc::numChannels(source.encoding);
-
-  if (source.step < source.width * byte_depth * num_channels) {
-    std::stringstream ss;
-    ss << "Image is wrongly formed: step < width * byte_depth * num_channels  "
-          "or  "
-       << source.step << " != " << source.width << " * " << byte_depth << " * "
-       << num_channels;
-    throw Exception(ss.str());
-  }
-
-  if (source.height * source.step != source.data.size()) {
-    std::stringstream ss;
-    ss << "Image is wrongly formed: height * step != size  or  "
-       << source.height << " * " << source.step << " != " << source.data.size();
-    throw Exception(ss.str());
-  }
-
-  // If the endianness is the same as locally, share the data
-  cv::Mat mat(source.height, source.width, source_type,
-              const_cast<uchar*>(&source.data[0]), source.step);
-  if ((boost::endian::order::native == boost::endian::order::big &&
-       source.is_bigendian) ||
-      (boost::endian::order::native == boost::endian::order::little &&
-       !source.is_bigendian) ||
-      byte_depth == 1)
-    return mat;
-
-  // Otherwise, reinterpret the data as bytes and switch the channels
-  // accordingly
-  mat = cv::Mat(source.height, source.width,
-                CV_MAKETYPE(CV_8U, num_channels * byte_depth),
-                const_cast<uchar*>(&source.data[0]), source.step);
-  cv::Mat mat_swap(source.height, source.width, mat.type());
-
-  std::vector<int> fromTo;
-  fromTo.reserve(num_channels * byte_depth);
-  for (int i = 0; i < num_channels; ++i)
-    for (int j = 0; j < byte_depth; ++j) {
-      fromTo.push_back(byte_depth * i + j);
-      fromTo.push_back(byte_depth * i + byte_depth - 1 - j);
-    }
-  cv::mixChannels(std::vector<cv::Mat>(1, mat),
-                  std::vector<cv::Mat>(1, mat_swap), fromTo);
-
-  // Interpret mat_swap back as the proper type
-  mat_swap.reshape(num_channels);
-
-  return mat_swap;
 }
 
 } // namespace beam_cv


### PR DESCRIPTION
builds on ubuntu 18.  the cv_bridge function was used in beam_colorize.  beam_colorize tests still pass, but they do not use the SetImage function  signature for ROS images.  If there's any code that uses that its worth testing