### PR TITLE
add lie algebra functions

### DIFF
--- a/beam_utils/include/beam_utils/math.h
+++ b/beam_utils/include/beam_utils/math.h
@@ -227,11 +227,25 @@ Eigen::MatrixXd KroneckerProduct(Eigen::MatrixXd A, Eigen::MatrixXd B);
 beam::Vec3 RToLieAlgebra(const beam::Mat3 R);
 
 /**
+ * @brief Convert from quaternion to its associated Lie Algebra
+ * @param q quaternion
+ * @return 3x1 vector representing R in Lie Algebra space
+ **/
+beam::Vec3 QToLieAlgebra(const Quaternion& q);
+
+/**
  * @brief Convert from Lie Algebra to its associated rotation matrix
  * @param eps rotation in Lie Algebra space
  * @return rotation matrix
  **/
 beam::Mat3 LieAlgebraToR(const beam::Vec3 eps);
+
+/**
+ * @brief Convert from Lie Algebra to its associated quaternion
+ * @param eps rotation in Lie Algebra space
+ * @return quaternion
+ **/
+Quaternion LieAlgebraToQ(const beam::Vec3 eps);
 
 /**
  * @brief Linear interpolation of transformations using a method in Tim
@@ -449,11 +463,12 @@ Eigen::Matrix4d VectorToEigenTransform(const std::vector<double>& v);
 Eigen::Matrix4d VectorToEigenTransform(const std::vector<float>& v);
 
 /**
- * @brief Converts an Eigen Matrix4d (transform) to a vector of 16 doubles. The points are read from left to right, then down.
+ * @brief Converts an Eigen Matrix4d (transform) to a vector of 16 doubles. The
+ * points are read from left to right, then down.
  * @param T transform of size 4 x 4
  * @return v vector of size 4 x 4 = 16
  */
- std::vector<double> EigenTransformToVector(const Eigen::Matrix4d& T);
+std::vector<double> EigenTransformToVector(const Eigen::Matrix4d& T);
 
 /**
  * @brief outputs transform to some stream with as the following:

--- a/beam_utils/src/math.cpp
+++ b/beam_utils/src/math.cpp
@@ -408,8 +408,18 @@ Eigen::Vector3d RToLieAlgebra(const Eigen::Matrix3d R) {
   return InvSkewTransform(R.log());
 }
 
+Eigen::Vector3d QToLieAlgebra(const Eigen::Quaterniond& q) {
+  Eigen::Matrix3d R = q.normalized().toRotationMatrix();
+  return RToLieAlgebra(R);
+}
+
 Eigen::Matrix3d LieAlgebraToR(const Eigen::Vector3d eps) {
   return SkewTransform(eps).exp();
+}
+
+Eigen::Quaterniond LieAlgebraToQ(const Eigen::Vector3d eps) {
+  Eigen::Quaterniond q(LieAlgebraToR(eps));
+  return q.normalized();
 }
 
 beam::Mat4 InterpolateTransform(const beam::Mat4& m1, const beam::TimePoint& t1,
@@ -665,12 +675,10 @@ Eigen::Matrix4d VectorToEigenTransform(const std::vector<double>& v) {
   return T;
 }
 
-std::vector<double> EigenTransformToVector(const Eigen::Matrix4d& T){
+std::vector<double> EigenTransformToVector(const Eigen::Matrix4d& T) {
   std::vector<double> v;
-  for (int i = 0; i < 4; i ++){
-    for (int j = 0; j < 4; j ++){
-      v.push_back(T(i,j));
-    }
+  for (int i = 0; i < 4; i++) {
+    for (int j = 0; j < 4; j++) { v.push_back(T(i, j)); }
   }
   return v;
 }


### PR DESCRIPTION
PR that adds two functions:
1. QToLieAlgebra, which is the analog of RToLieAlgebra but deals with quaternions instead of rotation matrices
2. LieAlgebraToQ, which is the analog of LieAlgebraToR but deals with quaternions instead of rotation matrices


