### PR TITLE
Improve raycast

### DIFF
--- a/beam_cv/include/beam_cv/Raycast.h
+++ b/beam_cv/include/beam_cv/Raycast.h
@@ -61,19 +61,18 @@ public:
   template <typename func>
   void Execute(float threshold, func behaviour) {
     BEAM_INFO("Performing ray casting.");
-    // create copied point cloud to use for kdtree
-    pcl::PointCloud<pcl::PointXYZ>::Ptr template_cloud =
+    // create a pointcloud with only points that have projected into the image
+    pcl::PointCloud<pcl::PointXYZ>::Ptr search_cloud =
         std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
-    for (size_t i = 0; i < cloud_->points.size(); i++) {
-      pcl::PointXYZ p(cloud_->points[i].x, cloud_->points[i].y,
-                      cloud_->points[i].z);
-      template_cloud->points.push_back(p);
-    }
+
+    // each entry of this vec contains the associated original point id
+    std::vector<int> search_cloud_pt_to_orig_cloud_pt;    
+
     // create image mask where white pixels = projection hit
     cv::Mat1b hit_mask(model_->GetHeight(), model_->GetWidth());
     for (uint32_t i = 0; i < cloud_->points.size(); i++) {
       Eigen::Vector3d point(cloud_->points[i].x, cloud_->points[i].y,
-                            cloud_->points[i].z);
+                            cloud_->points[i].z);                      
 
       bool in_image = false;
       Eigen::Vector2d coords;
@@ -85,19 +84,25 @@ public:
       uint16_t col = coords(0, 0);
       uint16_t row = coords(1, 0);
       hit_mask.at<uchar>(row, col) = 255;
+      search_cloud_pt_to_orig_cloud_pt.push_back(i);
+      search_cloud.push_back(pcl::PointXYZ(point[0], point[1], point[2]));
     }
+
     // create kdtree
     pcl::KdTreeFLANN<pcl::PointXYZ> kdtree;
-    kdtree.setInputCloud(template_cloud);
-    // cast ray for every pixel
+    kdtree.setInputCloud(search_cloud);
+
+    // cast ray for every pixel in the hit mask
     for (int row = 0; row < image_->rows; row++) {
       for (int col = 0; col < image_->cols; col++) {
         if (hit_mask.at<uchar>(row, col) == 255) {
           Eigen::Vector3d ray(0, 0, 0);
+
           // get direction vector
           Eigen::Vector2i input_point(col, row);
           Eigen::Vector3d point;
           if (!model_->BackProject(input_point, point)) { return; }
+          
           // while loop to ray trace
           uint16_t raypt = 0;
           while (raypt <= 20) {
@@ -106,17 +111,20 @@ public:
             search_point.x = ray(0, 0);
             search_point.y = ray(1, 0);
             search_point.z = ray(2, 0);
+            
             // search for closest point to ray
             std::vector<int> point_idx(1);
             std::vector<float> point_distance(1);
             kdtree.nearestKSearch(search_point, 1, point_idx, point_distance);
             float distance = sqrt(point_distance[0]);
+            
             // if the point is within threshold then call behaviour
             if (distance < threshold) {
               int position[2];
               position[0] = row;
               position[1] = col;
-              behaviour(image_, cloud_, position, point_idx[0]);
+              int point_idx_orig = search_cloud_pt_to_orig_cloud_pt[point_idx[0]];
+              behaviour(image_, cloud_, position, point_idx_orig);
               break;
             } else {
               raypt++;

--- a/beam_cv/include/beam_cv/Raycast.h
+++ b/beam_cv/include/beam_cv/Raycast.h
@@ -85,7 +85,7 @@ public:
       uint16_t row = coords(1, 0);
       hit_mask.at<uchar>(row, col) = 255;
       search_cloud_pt_to_orig_cloud_pt.push_back(i);
-      search_cloud.push_back(pcl::PointXYZ(point[0], point[1], point[2]));
+      search_cloud->push_back(pcl::PointXYZ(point[0], point[1], point[2]));
     }
 
     // create kdtree

--- a/beam_cv/include/beam_cv/Raycast.h
+++ b/beam_cv/include/beam_cv/Raycast.h
@@ -40,8 +40,11 @@ public:
    */
   Raycast(typename pcl::PointCloud<PointType>::Ptr cloud_i,
           std::shared_ptr<beam_calibration::CameraModel> model_i,
-          std::shared_ptr<cv::Mat> image_i)
-      : cloud_(cloud_i), model_(model_i), image_(image_i) {}
+          std::shared_ptr<cv::Mat> image_i, int max_ray_extensions = 20)
+      : cloud_(cloud_i),
+        model_(model_i),
+        image_(image_i),
+        max_ray_extensions_(max_ray_extensions) {}
 
   /**
    * @brief Default destructor
@@ -66,13 +69,13 @@ public:
         std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
 
     // each entry of this vec contains the associated original point id
-    std::vector<int> search_cloud_pt_to_orig_cloud_pt;    
+    std::vector<int> search_cloud_pt_to_orig_cloud_pt;
 
     // create image mask where white pixels = projection hit
     cv::Mat1b hit_mask(model_->GetHeight(), model_->GetWidth());
     for (uint32_t i = 0; i < cloud_->points.size(); i++) {
       Eigen::Vector3d point(cloud_->points[i].x, cloud_->points[i].y,
-                            cloud_->points[i].z);                      
+                            cloud_->points[i].z);
 
       bool in_image = false;
       Eigen::Vector2d coords;
@@ -95,43 +98,43 @@ public:
     // cast ray for every pixel in the hit mask
     for (int row = 0; row < image_->rows; row++) {
       for (int col = 0; col < image_->cols; col++) {
-        if (hit_mask.at<uchar>(row, col) == 255) {
-          Eigen::Vector3d ray(0, 0, 0);
-
-          // get direction vector
-          Eigen::Vector2i input_point(col, row);
-          Eigen::Vector3d point;
-          if (!model_->BackProject(input_point, point)) { return; }
+        if (hit_mask.at<uchar>(row, col) != 255) { continue; }
           
-          // while loop to ray trace
-          uint16_t raypt = 0;
-          while (raypt <= 20) {
-            // get point at end of ray
-            pcl::PointXYZ search_point;
-            search_point.x = ray(0, 0);
-            search_point.y = ray(1, 0);
-            search_point.z = ray(2, 0);
-            
-            // search for closest point to ray
-            std::vector<int> point_idx(1);
-            std::vector<float> point_distance(1);
-            kdtree.nearestKSearch(search_point, 1, point_idx, point_distance);
-            float distance = sqrt(point_distance[0]);
-            
-            // if the point is within threshold then call behaviour
-            if (distance < threshold) {
-              int position[2];
-              position[0] = row;
-              position[1] = col;
-              int point_idx_orig = search_cloud_pt_to_orig_cloud_pt[point_idx[0]];
-              behaviour(image_, cloud_, position, point_idx_orig);
-              break;
-            } else {
-              raypt++;
-              ray(0, 0) = ray(0, 0) + distance * point(0, 0);
-              ray(1, 0) = ray(1, 0) + distance * point(1, 0);
-              ray(2, 0) = ray(2, 0) + distance * point(2, 0);
-            }
+        Eigen::Vector3d ray(0, 0, 0);
+
+        // get direction vector
+        Eigen::Vector2i input_point(col, row);
+        Eigen::Vector3d point;
+        if (!model_->BackProject(input_point, point)) { return; }
+
+        // while loop to ray trace
+        uint16_t raypt = 0;
+        while (raypt <= max_ray_extensions_) {
+          // get point at end of ray
+          pcl::PointXYZ search_point;
+          search_point.x = ray(0, 0);
+          search_point.y = ray(1, 0);
+          search_point.z = ray(2, 0);
+
+          // search for closest point to ray
+          std::vector<int> point_idx(1);
+          std::vector<float> point_distance(1);
+          kdtree.nearestKSearch(search_point, 1, point_idx, point_distance);
+          float distance = sqrt(point_distance[0]);
+
+          // if the point is within threshold then call behaviour
+          if (distance < threshold) {
+            int position[2];
+            position[0] = row;
+            position[1] = col;
+            int point_idx_orig =
+            search_cloud_pt_to_orig_cloud_pt[point_idx[0]]; behaviour(image_,
+            cloud_, position, point_idx_orig); break;
+          } else {
+            raypt++;
+            ray(0, 0) = ray(0, 0) + distance * point(0, 0);
+            ray(1, 0) = ray(1, 0) + distance * point(1, 0);
+            ray(2, 0) = ray(2, 0) + distance * point(2, 0);
           }
         }
       }
@@ -179,5 +182,6 @@ protected:
   typename pcl::PointCloud<PointType>::Ptr cloud_;
   std::shared_ptr<beam_calibration::CameraModel> model_;
   std::shared_ptr<cv::Mat> image_;
+  int max_ray_extensions_;
 };
 } // namespace beam_cv

--- a/beam_cv/include/beam_cv/Raycast.h
+++ b/beam_cv/include/beam_cv/Raycast.h
@@ -99,7 +99,7 @@ public:
     for (int row = 0; row < image_->rows; row++) {
       for (int col = 0; col < image_->cols; col++) {
         if (hit_mask.at<uchar>(row, col) != 255) { continue; }
-          
+
         Eigen::Vector3d ray(0, 0, 0);
 
         // get direction vector
@@ -127,9 +127,9 @@ public:
             int position[2];
             position[0] = row;
             position[1] = col;
-            int point_idx_orig =
-            search_cloud_pt_to_orig_cloud_pt[point_idx[0]]; behaviour(image_,
-            cloud_, position, point_idx_orig); break;
+            int point_idx_orig = search_cloud_pt_to_orig_cloud_pt[point_idx[0]];
+            behaviour(image_, cloud_, position, point_idx_orig);
+            break;
           } else {
             raypt++;
             ray(0, 0) = ray(0, 0) + distance * point(0, 0);


### PR DESCRIPTION
This PR suggests a change to the raytracer where we only build a kd search tree with the points that have projeted into the image plane. For my one image test, this sped things up from 24 minutes to 9 minues (2.6x faster)